### PR TITLE
make ceaseFire work on each scroll trigger

### DIFF
--- a/js/jquery.endless-scroll.js
+++ b/js/jquery.endless-scroll.js
@@ -78,6 +78,11 @@
     if (firing === true)
     {
       $(this).scroll(function() {
+        if (options.ceaseFire.apply(this) === true)
+        {
+          firing = false;
+          return; // Scroll will still get called, but nothing will happen
+        }
         if (this == document) {
           var is_scrollable = $(document).height() - $(window).height() <= $(window).scrollTop() + options.bottomPixels;
         } else {


### PR DESCRIPTION
Making ceaseFire work the way I would expect it to, called on each scroll, ending the scroll if ceaseFire returns true

https://github.com/fredwu/jquery-endless-scroll/issues/4
