### PR TITLE
Issue with inner_wrap and the first scroll event

### DIFF
--- a/js/jquery.endless-scroll.js
+++ b/js/jquery.endless-scroll.js
@@ -87,7 +87,7 @@
           // calculates the actual height of the scrolling container
           var inner_wrap = $(".endless_scroll_inner_wrap", this);
           if (inner_wrap.length == 0) {
-            $(this).wrapInner("<div class=\"endless_scroll_inner_wrap\" />");
+            inner_wrap = $(this).wrapInner("<div class=\"endless_scroll_inner_wrap\" />").find(".endless_scroll_inner_wrap");
           }
           var is_scrollable = inner_wrap.length > 0 &&
             (inner_wrap.height() - $(this).height() <= $(this).scrollTop() + options.bottomPixels);


### PR DESCRIPTION
Actually, if 'inner_wrap' does not exist, the script creates it. However, it was forgotten to assign this jquery element after creating it, so 'is_scrollable' is false in the first scroll event (only in this case).
