### PR TITLE
refactor default options merge to avert side effects.

### DIFF
--- a/js/jquery.endless-scroll.js
+++ b/js/jquery.endless-scroll.js
@@ -64,7 +64,7 @@
       ceaseFire: function() { return false; }
     };
 
-    var options = $.extend(defaults, options);
+    var options = $.extend({}, defaults, options);
 
     var firing       = true;
     var fired        = false;


### PR DESCRIPTION
setting options this way:

```
$.extend(defaults, options);
```

will overwrite the default variable with the param `options`. 

For example, If there are two endless scrolls on the page, the 2nd endless scroll could receive 'dirty' defaults from the first call.

This:

```
$.extend({}, defaults, options);
```

won't do that.  It keeps defaults clean and separate from the intended options.
