### PR TITLE
Changed the usage instruction to be IE friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ In a typical scenario, you won't be using the `data` option, but rather the `cal
 
 ``` js
 // using default options
-$(document).endlessScroll();
+$(window).endlessScroll();
 // using some custom options
-$(document).endlessScroll({
+$(window).endlessScroll({
   fireOnce: false,
   fireDelay: false,
   loader: "<div class="loading"><div>",


### PR DESCRIPTION
Spent an hour trying to figure out why this wasn't working in IE, everything looked fine but didn't think until later about $(document).scroll not acting properly in IE.  $(window) seems to work well in all browsers, and android mobile phones.
