### PR TITLE
Use `do` for pass `$ = jQuery`

### DIFF
--- a/src/jquery.endless-scroll.coffee
+++ b/src/jquery.endless-scroll.coffee
@@ -264,7 +264,6 @@ class EndlessScroll
     else
       @fired = false
 
-(($) ->
+do ($ = jQuery) ->
   $.fn.endlessScroll = (options) ->
     new EndlessScroll(this, options).run()
-)(jQuery)


### PR DESCRIPTION
``` coffeescript
do ($ = jQuery) ->
  $.fn.endlessScroll = (options) ->
    new EndlessScroll(this, options).run()
```

... is more much better than:

``` coffeescript
(($) ->
  $.fn.endlessScroll = (options) ->
    new EndlessScroll(this, options).run()
)(jQuery)
```
