### PR TITLE
More efficient scroll function

### DIFF
--- a/js/jquery.endless-scroll.js
+++ b/js/jquery.endless-scroll.js
@@ -164,7 +164,7 @@ EndlessScroll = (function() {
 
   EndlessScroll.prototype.detectTarget = function(scope) {
     this.target = scope;
-    return this.targetId = $(this.target).attr('id');
+    return this.targetId = this.target.get(0).id;
   };
 
   EndlessScroll.prototype.detectScrollDirection = function() {


### PR DESCRIPTION
I just tried using this plugin for the first time, so I don't know the ins and outs necessarily. But the `scroll` event triggers a _lot_ when scrolling, and in this case the `detectTarget` function that is bound to the `scroll` event is somewhat inefficient.

Without actually changing anything in the way the plugin or that function work, we can make it much more efficient by using plain JavaScript where possible.

In this case, jQuery is definitely not needed to get an element's `id`. Also, as far as I can tell `scope` will always be a jQuery object already because the plugin is called via the jQuery selector (e.g. `$('#my-element').endlessScroll()`.

So, 1) we don't need to re-wrap `$(this.target)`, since `this.target` is always a jQuery object already (again, I could be wrong here, I don't know the ins and outs of the plugin), and 2) we can get the plain JS dom element using `.get(0)` and then just call the plain JS `id` property on it; much more efficient.

Ideally though, this function should probably just return true if `this.target` and `this.targetId` are already present, but that actually changes the way the function works and could mess up on pages that are constantly having their DOM updated and changed.
