### PR TITLE
Configurable parameter insertAfter and insertBefore overriden by default

### DIFF
--- a/js/jquery.endless-scroll.js
+++ b/js/jquery.endless-scroll.js
@@ -154,10 +154,10 @@ EndlessScroll = (function() {
   EndlessScroll.prototype.setInsertPositionsWhenNecessary = function() {
     var container;
     container = "" + this.target.selector + " div.endless_scroll_inner_wrap";
-    if (defaults.insertBefore === null) {
+    if (this.options.insertBefore === null) {
       this.options.insertBefore = "" + container + " div:first";
     }
-    if (defaults.insertAfter === null) {
+    if (this.options.insertAfter === null) {
       return this.options.insertAfter = "" + container + " div:last";
     }
   };


### PR DESCRIPTION
When integrating the Plugin, I faced an issue that my content was not getting replaced at the position mentioned in the configuration

$('#scrollableList').endlessScroll({
        fireOnce: false,
        inflowPixels: 1,
        insertAfter: '#scrollableList div:last',
        insertBefore: '#scrollableList div:last',
        loader: ''
});

insertAfter and insertBefore were overriden in the function EndlessScroll.prototype.setInsertPositionsWhenNecessary since we are using default to check if insertAfter and insertBefore are provided. We should be checking for options.insertAfter and options.insertBefor
